### PR TITLE
update docs to use philipssoftware image as example

### DIFF
--- a/logproxy-filter-replace/README.md
+++ b/logproxy-filter-replace/README.md
@@ -35,7 +35,7 @@ Below is an example `manifest.yml` for deployment to Cloud foundry:
 applications:
 - name: logproxy-filter-replace
   docker:
-    image: jdelucaa/logproxy-filter-replace:latest
+    image: philipssoftware/logproxy-filter-replace:latest
   env:
     FILTER_CONFIG: "Ww0KICB7DQogICAgInBhdHRlcm4iOiAiKChbQS1aXSlcXHcrKSIsDQogICAgInJlcGxhY2UiOiAiPEZvb0Jhcj4iDQogIH0NCl0NCg=="
     LOGPROXY_QUEUE: channel


### PR DESCRIPTION
The example in the `filter-replace` plugin was referencing the docker image from my personal account. I updated it to reference the philipssoftware one.