### PR TITLE
fix: Process the entire regex at once instead of replacing individual components

### DIFF
--- a/logproxy-filter-replace/main.go
+++ b/logproxy-filter-replace/main.go
@@ -44,12 +44,10 @@ func (f Filter) Filter(msg logging.Resource) (logging.Resource, bool, bool, erro
 	modified := false
 	for _, filter := range f.filterList {
 		decodedMsg, _ := base64.StdEncoding.DecodeString(msg.LogData.Message)
-		if req := filter.pattern.FindAllStringSubmatch(string(decodedMsg), -1); req != nil {
+		if req := filter.pattern.FindAllString(string(decodedMsg), -1); req != nil {
 			modifiedMsg := string(decodedMsg)
-			for i := range req {
-				for j := range req[i] {
-					modifiedMsg = strings.ReplaceAll(modifiedMsg, req[i][j], filter.replace)
-				}
+			for _, match := range req {
+				modifiedMsg = strings.ReplaceAll(modifiedMsg, match, filter.replace)
 			}
 			msg.LogData.Message = base64.StdEncoding.EncodeToString([]byte(modifiedMsg))
 			modified = true


### PR DESCRIPTION
This ensures that the entire regex is processed and replaced properly without introducing errors from partial matches. It's also enables to use the | (or condition) on regex.

Updated also the unit tests to use Base64 on the message to be accordingly to this change [Fix all plugins](https://github.com/philips-software/logproxy-plugins/commit/25357e93580afe578c0ec90f2c51a73c5773dd61#diff-0414f84d5d66f4ca8b4c4c26a749932b51b19458602bacba61e82e4e0caff710)
Added some more messages to be tested on the unit test.

Tests are passing:
![image](https://github.com/user-attachments/assets/32a0f826-952a-47f9-bee5-b3f3161099b2)
